### PR TITLE
Revise proxy to use objects instead of prototypes

### DIFF
--- a/dist/firmata.js
+++ b/dist/firmata.js
@@ -26,6 +26,7 @@
         this.connection = opts.connection;
         this.name = opts.name;
         this.board = "";
+        this.myself = this;
       }
 
       Firmata.prototype.commands = function() {
@@ -39,7 +40,7 @@
           callback(null);
           return _this.connection.emit('connect');
         });
-        return this.proxyMethods(this.commands, this.board, Firmata);
+        return this.proxyMethods(this.commands, this.board, this.myself);
       };
 
       Firmata.prototype.disconnect = function() {

--- a/src/firmata.coffee
+++ b/src/firmata.coffee
@@ -18,6 +18,7 @@ namespace "Cylon.Adaptor", ->
       @connection = opts.connection
       @name = opts.name
       @board = ""
+      @myself = this
 
     commands: ->
       ['pins', 'pinMode', 'digitalRead', 'digitalWrite', 'analogRead', 'analogWrite', 'pwmWrite', 'servoWrite',
@@ -29,7 +30,7 @@ namespace "Cylon.Adaptor", ->
         (callback)(null)
         @connection.emit 'connect'
 
-      @proxyMethods @commands, @board, Firmata
+      @proxyMethods @commands, @board, @myself
 
     disconnect: ->
       Logger.debug "Disconnecting from board '#{@name}'..."


### PR DESCRIPTION
Revise proxy to attach functions to objects directly instead of their prototypes.
