### PR TITLE
Update to include i2c support

### DIFF
--- a/dist/firmata.js
+++ b/dist/firmata.js
@@ -80,26 +80,33 @@
         return this.board.analogWrite(pin, value);
       };
 
-      Firmata.prototype.i2cConfig = function(delay) {
+      Firmata.prototype.i2cWrite = function(address, cmd, buff, callback) {
+        if (callback == null) {
+          callback = null;
+        }
+        if (!this.i2cReady) {
+          this._i2cConfig();
+        }
+        return this.board.sendI2CWriteRequest(address, [cmd].concat(buff));
+      };
+
+      Firmata.prototype.i2cRead = function(address, cmd, length, callback) {
+        if (callback == null) {
+          callback = null;
+        }
+        if (!this.i2cReady) {
+          this._i2cConfig();
+        }
+        this.board.sendI2CWriteRequest(address, [cmd]);
+        return this.board.sendI2CReadRequest(address, length, callback);
+      };
+
+      Firmata.prototype._i2cConfig = function(delay) {
         if (delay == null) {
           delay = null;
         }
         this.board.sendI2CConfig(delay);
         return this.i2cReady = true;
-      };
-
-      Firmata.prototype.i2cWrite = function(address, data) {
-        if (!i2cReady) {
-          this.i2cConfig;
-        }
-        return this.board.sendI2CWriteRequest(address, data);
-      };
-
-      Firmata.prototype.i2cRead = function(address, length, callback) {
-        if (!i2cReady) {
-          this.i2cConfig;
-        }
-        return this.board.sendI2CReadRequest(address, length, callback);
       };
 
       return Firmata;

--- a/src/firmata.coffee
+++ b/src/firmata.coffee
@@ -61,15 +61,15 @@ namespace "Cylon.Adaptors", ->
       @board.pinMode pin, @board.MODES.SERVO
       @board.analogWrite pin, value
 
-    i2cConfig: (delay = null) ->
-      @board.sendI2CConfig delay
-      @i2cReady = true
+    i2cWrite: (address, cmd, buff, callback = null) ->
+      @_i2cConfig() unless @i2cReady
+      @board.sendI2CWriteRequest address, [cmd].concat(buff)
 
-    i2cWrite: (address, data) ->
-      @i2cConfig unless i2cReady
-      @board.sendI2CWriteRequest address, data
-
-    i2cRead: (address, length, callback) ->
-      @i2cConfig unless i2cReady
+    i2cRead: (address, cmd, length, callback = null) ->
+      @_i2cConfig() unless @i2cReady
+      @board.sendI2CWriteRequest address, [cmd]
       @board.sendI2CReadRequest address, length, callback
 
+    _i2cConfig: (delay = null) ->
+      @board.sendI2CConfig delay
+      @i2cReady = true


### PR DESCRIPTION
Bug Fixes:
1. Correct reset on connection disconnect, close() method does not exist in firmata.board
2. Fixes i2cRead, i2cWrite and i2cConfig to work with new i2c drivers.
