### PR TITLE
Add unified method for triggering callbacks and emitting events.

### DIFF
--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -83,9 +83,9 @@ Adaptor.prototype.disconnect = function(callback) {
 Adaptor.prototype.digitalRead = function(pin, callback) {
   this.pinMode(pin, "input");
 
-  var adCallback = function(readVal) {
-    callback(null, readVal);
-  };
+  var adCallback = function(value) {
+    this.emitAndTrigger("digitalRead", pin, value, callback);
+  }.bind(this);
 
   this.board.digitalRead(pin, adCallback);
 };
@@ -98,9 +98,10 @@ Adaptor.prototype.digitalRead = function(pin, callback) {
  * @return {null}
  * @publish
  */
-Adaptor.prototype.digitalWrite = function(pin, value) {
+Adaptor.prototype.digitalWrite = function(pin, value, callback) {
   this.pinMode(pin, "output");
   this.board.digitalWrite(pin, value);
+  this.emitAndTrigger("digitalWrite", pin, value, callback);
 };
 
 /**
@@ -113,9 +114,9 @@ Adaptor.prototype.digitalWrite = function(pin, value) {
  * @publish
  */
 Adaptor.prototype.analogRead = function(pin, callback) {
-  var adCallback = function(readVal) {
-    callback(null, readVal);
-  };
+  var adCallback = function(value) {
+    this.emitAndTrigger("analogRead", pin, value, callback);
+  }.bind(this);
 
   this.board.analogRead(pin, adCallback);
 };
@@ -128,10 +129,12 @@ Adaptor.prototype.analogRead = function(pin, callback) {
  * @return {null}
  * @publish
  */
-Adaptor.prototype.analogWrite = function(pin, value) {
+Adaptor.prototype.analogWrite = function(pin, value, callback) {
   value = (value).toScale(0, 255);
   this.pinMode(this.board.analogPins[pin], "analog");
   this.board.analogWrite(this.board.analogPins[pin], value);
+
+  this.emitAndTrigger("analogRead", pin, value, callback);
 };
 
 /**
@@ -142,10 +145,12 @@ Adaptor.prototype.analogWrite = function(pin, value) {
  * @return {null}
  * @publish
  */
-Adaptor.prototype.pwmWrite = function(pin, value) {
+Adaptor.prototype.pwmWrite = function(pin, value, callback) {
   value = (value).toScale(0, 255);
   this.pinMode(pin, "pwm");
   this.board.analogWrite(pin, value);
+
+  this.emitAndTrigger("pwmWrite", pin, value, callback);
 };
 
 /**
@@ -156,10 +161,13 @@ Adaptor.prototype.pwmWrite = function(pin, value) {
  * @return {null}
  * @publish
  */
-Adaptor.prototype.servoWrite = function(pin, value) {
+Adaptor.prototype.servoWrite = function(pin, value, callback) {
   value = (value).toScale(0, 180);
   this.pinMode(pin, "servo");
   this.board.servoWrite(pin, value);
+  if (typeof(callback) === "function") {
+    callback(null, value);
+  }
 };
 
 /**
@@ -235,5 +243,12 @@ Adaptor.prototype._convertPinMode = function(mode) {
       return this.board.MODES.SERVO ;
     default:
       return this.board.MODES.INPUT ;
+  }
+};
+
+Adaptor.prototype.emitAndTrigger = function(event, pin, value, callback) {
+  this.emit(event, pin, num);
+  if (typeof(callback) === "function") {
+    callback(null, );
   }
 };

--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -53,8 +53,7 @@ Adaptor.prototype.commands = [
  */
 Adaptor.prototype.connect = function(callback) {
   this.board = new Firmata.Board(this.port, function(data) {
-    this.emit("connect");
-    callback(null, data);
+    this._respond("connect", callback, data);
   }.bind(this));
 
   this.proxyMethods(this.commands, this.board, this);
@@ -83,11 +82,9 @@ Adaptor.prototype.disconnect = function(callback) {
 Adaptor.prototype.digitalRead = function(pin, callback) {
   this.pinMode(pin, "input");
 
-  var adCallback = function(value) {
-    this.emitAndTrigger("digitalRead", pin, value, callback);
-  }.bind(this);
-
-  this.board.digitalRead(pin, adCallback);
+  this.board.digitalRead(pin, function(value) {
+    this._respond("digitalRead", callback, value, pin);
+  }.bind(this));
 };
 
 /**
@@ -101,7 +98,7 @@ Adaptor.prototype.digitalRead = function(pin, callback) {
 Adaptor.prototype.digitalWrite = function(pin, value, callback) {
   this.pinMode(pin, "output");
   this.board.digitalWrite(pin, value);
-  this.emitAndTrigger("digitalWrite", pin, value, callback);
+  this._respond("digitalWrite", callback, value, pin);
 };
 
 /**
@@ -114,11 +111,9 @@ Adaptor.prototype.digitalWrite = function(pin, value, callback) {
  * @publish
  */
 Adaptor.prototype.analogRead = function(pin, callback) {
-  var adCallback = function(value) {
-    this.emitAndTrigger("analogRead", pin, value, callback);
-  }.bind(this);
-
-  this.board.analogRead(pin, adCallback);
+  this.board.analogRead(pin, function(value) {
+    this._respond("analogRead", callback, value, pin);
+  }.bind(this));
 };
 
 /**
@@ -134,7 +129,7 @@ Adaptor.prototype.analogWrite = function(pin, value, callback) {
   this.pinMode(this.board.analogPins[pin], "analog");
   this.board.analogWrite(this.board.analogPins[pin], value);
 
-  this.emitAndTrigger("analogRead", pin, value, callback);
+  this._respond("analogWrite", callback, value, pin);
 };
 
 /**
@@ -150,7 +145,7 @@ Adaptor.prototype.pwmWrite = function(pin, value, callback) {
   this.pinMode(pin, "pwm");
   this.board.analogWrite(pin, value);
 
-  this.emitAndTrigger("pwmWrite", pin, value, callback);
+  this._respond("pwmWrite", callback, value, pin);
 };
 
 /**
@@ -246,9 +241,15 @@ Adaptor.prototype._convertPinMode = function(mode) {
   }
 };
 
-Adaptor.prototype.emitAndTrigger = function(event, pin, value, callback) {
-  this.emit(event, pin, num);
-  if (typeof(callback) === "function") {
-    callback(null, );
+// Emits an event, and triggers a callback as appropriate.
+//
+// Additional params beyond event name and callback are interpreted as values
+Adaptor.prototype._respond = function(event, callback) {
+  var args = [].slice.call(arguments, 2);
+
+  this.emit.apply(this, [event].concat(args));
+
+  if (typeof callback === "function") {
+    callback.apply(this, args);
   }
 };

--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -67,7 +67,7 @@ Adaptor.prototype.connect = function(callback) {
  */
 Adaptor.prototype.disconnect = function(callback) {
   this.board.reset();
-  callback();
+  this._respond("disconnect", callback);
 };
 
 /**
@@ -128,7 +128,6 @@ Adaptor.prototype.analogWrite = function(pin, value, callback) {
   value = (value).toScale(0, 255);
   this.pinMode(this.board.analogPins[pin], "analog");
   this.board.analogWrite(this.board.analogPins[pin], value);
-
   this._respond("analogWrite", callback, value, pin);
 };
 
@@ -144,7 +143,6 @@ Adaptor.prototype.pwmWrite = function(pin, value, callback) {
   value = (value).toScale(0, 255);
   this.pinMode(pin, "pwm");
   this.board.analogWrite(pin, value);
-
   this._respond("pwmWrite", callback, value, pin);
 };
 
@@ -160,9 +158,7 @@ Adaptor.prototype.servoWrite = function(pin, value, callback) {
   value = (value).toScale(0, 180);
   this.pinMode(pin, "servo");
   this.board.servoWrite(pin, value);
-  if (typeof(callback) === "function") {
-    callback(null, value);
-  }
+  this._respond("servoWrite", callback, value, pin);
 };
 
 /**
@@ -179,7 +175,7 @@ Adaptor.prototype.i2cWrite = function(address, cmd, buff, callback) {
   if (!this.i2cReady) { this.i2cConfig(2000); }
   cmd = (Array.isArray(cmd)) ? cmd : [cmd];
   this.board.sendI2CWriteRequest(address, cmd.concat(buff));
-  if ("function" === typeof(callback)) { callback(); }
+  this._respond("i2cWrite", callback);
 };
 
 /**
@@ -203,7 +199,7 @@ Adaptor.prototype.i2cRead = function(address, cmd, length, callback) {
     this.board.sendI2CWriteRequest(address, cmd);
   }
 
-  this.board.sendI2CReadRequest(address, length, function(data){
+  this.board.sendI2CReadRequest(address, length, function(data) {
     var err = null;
 
     if (data.name === "Error") {
@@ -211,8 +207,8 @@ Adaptor.prototype.i2cRead = function(address, cmd, length, callback) {
       data = null;
     }
 
-    callback(err, data);
-  });
+    this._respond("i2cRead", callback, err, data);
+  }.bind(this));
 };
 
 Adaptor.prototype.pinMode = function(pin, mode) {

--- a/spec/lib/firmata.spec.js
+++ b/spec/lib/firmata.spec.js
@@ -131,7 +131,7 @@ describe("Cylon.Adaptors.Firmata", function() {
 
     it("uses #digitalRead to get the value from the pin", function() {
       expect(firmata.board.digitalRead).to.be.calledWith(4);
-      expect(callback).to.be.calledWith(null, 1);
+      expect(callback).to.be.calledWith(1, 4);
     });
   });
 
@@ -166,7 +166,7 @@ describe("Cylon.Adaptors.Firmata", function() {
 
     it("uses #analogRead to get the pin value", function() {
       expect(firmata.board.analogRead).to.be.calledWith(4);
-      expect(callback).to.be.calledWith(null, 128);
+      expect(callback).to.be.calledWith(128, 4);
     });
   });
 


### PR DESCRIPTION
Should this pattern be extracted into the Adaptor parent class in Cylon core?

Additionally, for most Firmata methods that interface with boards, event/callbacks are now triggered with the pin number as the last value, for use in drivers.